### PR TITLE
Bugfix on navigation to product page

### DIFF
--- a/src/helpers/pathGenerators.ts
+++ b/src/helpers/pathGenerators.ts
@@ -33,7 +33,7 @@ export const generateCategoryPath = (slug: string): string => {
 
   collectPaths(slug);
 
-  return pathArray.join('/');
+  return pathArray.slice(1).join('/');
 };
 
 export const generateProductPath = (


### PR DESCRIPTION
## Description of Changes

Fix bug on navigation to a product page.
  
## Reasons for Changes

After merging PR with implemented navigation by categories appears the bug, that broke navigation to product page from a product card. The reason of this PR - is to fix this issue.